### PR TITLE
remove ping test, not a guarantee for internet connectivity

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -12,12 +12,6 @@ echo "0"   > /sys/class/gpio/gpio$SX1301_RESET_BCM_PIN/value
 sleep 0.1
 echo "$SX1301_RESET_BCM_PIN"  > /sys/class/gpio/unexport 
 
-# Test the connection, wait if needed.
-while [[ $(ping -c1 google.com 2>&1 | grep " 0% packet loss") == "" ]]; do
-  echo "[TTN Gateway]: Waiting for internet connection..."
-  sleep 30
-  done
-
 # If there's a remote config, try to update it
 if [ -d ../gateway-remote-config ]; then
     # First pull from the repo


### PR DESCRIPTION
I'm behind a firewall that doesn't allow ping, which results in 100% packet loss, but the internet connection is just fine. Mind removing the check altogether? Or can we introduce some other way of checking connection, or add a seam so it can be disabled?