### PR TITLE
use current hostname when installing from remote configuration

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -53,7 +53,7 @@ read -r -p "Do you want to use remote settings file? [y/N]" response
 response=${response,,} # tolower
 
 if [[ $response =~ ^(yes|y) ]]; then
-    NEW_HOSTNAME="ttn-gateway"
+    NEW_HOSTNAME=$(hostname)
     REMOTE_CONFIG=true
 else
     printf "       Host name [ttn-gateway]:"


### PR DESCRIPTION
If you are installing from remote configuration, then the current hostname will unconditionally be overwritten with `ttn-gateway`.

I think it's better to pick the current hostname, since the first time you install you most likely do it manually and you get the option to pick a new hostname (which defaults to `ttn-gateway`). Once your remote configuration has been merged, or when software has been updated you want to re-install, but not change the hostname.