### PR TITLE
Detect EUI without relying on interface names

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -35,7 +35,7 @@ echo "Gateway configuration:"
 # Try to get gateway ID from MAC address
 
 # Get first non-loopback network device that is currently connected
-NICS=$(ip link 2>&1 | grep "state UP" | grep -v LOOPBACK | sed -E 's/^[0-9]+: ([0-9a-z]+): .*/\1/')
+NICS=$(ip -oneline link show up 2>&1 | grep -v LOOPBACK | sed -E 's/^[0-9]+: ([0-9a-z]+): .*/\1/')
 if [[ -z $NICS ]]; then
     echo "ERROR: No network interface found. Cannot set gateway ID."
     exit 1

--- a/install.sh
+++ b/install.sh
@@ -43,8 +43,7 @@ fi
 GATEWAY_EUI_NIC=$(echo $NICS | cut -d " " -f1)
 
 # Then get EUI based on the MAC address of that device
-read GATEWAY_MAC </sys/class/net/$GATEWAY_EUI_NIC/address
-GATEWAY_EUI=$(echo $GATEWAY_MAC | sed 's/://g')
+GATEWAY_EUI=$(cat /sys/class/net/$GATEWAY_EUI_NIC/address | awk -F\: '{print $1$2$3"FFFE"$4$5$6}')
 GATEWAY_EUI=${GATEWAY_EUI^^} # toupper
 
 echo "Detected EUI $GATEWAY_EUI from $GATEWAY_EUI_NIC"

--- a/install.sh
+++ b/install.sh
@@ -33,18 +33,18 @@ fi
 echo "Gateway configuration:"
 
 # Try to get gateway ID from MAC address
-# First try eth0, if that does not exist, try wlan0 (for RPi Zero)
-GATEWAY_EUI_NIC="eth0"
-if [[ `grep "$GATEWAY_EUI_NIC" /proc/net/dev` == "" ]]; then
-    GATEWAY_EUI_NIC="wlan0"
-fi
 
-if [[ `grep "$GATEWAY_EUI_NIC" /proc/net/dev` == "" ]]; then
+# Get first non-loopback network device that is currently connected
+NICS=$(ip link 2>&1 | grep "state UP" | grep -v LOOPBACK | sed -E 's/^[0-9]+: ([0-9a-z]+): .*/\1/')
+if [[ -z $NICS ]]; then
     echo "ERROR: No network interface found. Cannot set gateway ID."
     exit 1
 fi
+GATEWAY_EUI_NIC=$(echo $NICS | cut -d " " -f1)
 
-GATEWAY_EUI=$(ip link show $GATEWAY_EUI_NIC | awk '/ether/ {print $2}' | awk -F\: '{print $1$2$3"FFFE"$4$5$6}')
+# Then get EUI based on the MAC address of that device
+read GATEWAY_MAC </sys/class/net/$GATEWAY_EUI_NIC/address
+GATEWAY_EUI=$(echo $GATEWAY_MAC | sed 's/://g')
 GATEWAY_EUI=${GATEWAY_EUI^^} # toupper
 
 echo "Detected EUI $GATEWAY_EUI from $GATEWAY_EUI_NIC"

--- a/install.sh
+++ b/install.sh
@@ -35,12 +35,11 @@ echo "Gateway configuration:"
 # Try to get gateway ID from MAC address
 
 # Get first non-loopback network device that is currently connected
-NICS=$(ip -oneline link show up 2>&1 | grep -v LOOPBACK | sed -E 's/^[0-9]+: ([0-9a-z]+): .*/\1/')
-if [[ -z $NICS ]]; then
+GATEWAY_EUI_NIC=$(ip -oneline link show up 2>&1 | grep -v LOOPBACK | sed -E 's/^[0-9]+: ([0-9a-z]+): .*/\1/' | head -1)
+if [[ -z $GATEWAY_EUI_NIC ]]; then
     echo "ERROR: No network interface found. Cannot set gateway ID."
     exit 1
 fi
-GATEWAY_EUI_NIC=$(echo $NICS | cut -d " " -f1)
 
 # Then get EUI based on the MAC address of that device
 GATEWAY_EUI=$(cat /sys/class/net/$GATEWAY_EUI_NIC/address | awk -F\: '{print $1$2$3"FFFE"$4$5$6}')


### PR DESCRIPTION
With `ip link` we can find all active network interfaces. We then take
the first active one and create an EUI based on its MAC address.

This way, the name of the interface does not matter, meaning that we can
support both predictable and non-predictable names.