### PR TITLE
Fix long running shell process

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -50,4 +50,4 @@ if [ -d ../gateway-remote-config ]; then
 fi
 
 # Fire up the forwarder.
-./poly_pkt_fwd
+exec ./poly_pkt_fwd


### PR DESCRIPTION
The shell spawned for start.sh is not required to run after
the packet forwared started running. This patch saves the resources
consumed by this extra shell process.