### PR TITLE
Always restart service, not just on-failure

### DIFF
--- a/ttn-gateway.service
+++ b/ttn-gateway.service
@@ -5,7 +5,7 @@ Description=The Things Network Gateway
 WorkingDirectory=/opt/ttn-gateway/bin/
 ExecStart=/opt/ttn-gateway/bin/start.sh
 SyslogIdentifier=ttn-gateway
-Restart=on-failure
+Restart=always
 RestartSec=5
 
 [Install]


### PR DESCRIPTION
`ttn-gateway` is restarted by `systemd` every time it stops with a failure, but `poly_pkt_fwd` returns success most of the time. This preq makes `systemd` restart our service in all cases. It can be still stopped with `systemctl stop ttn-gateway` if we want to actually stop it.